### PR TITLE
Authenticate users on both ILRI & CGIARAD domains

### DIFF
--- a/authmodules/mod_security_v0.1.php
+++ b/authmodules/mod_security_v0.1.php
@@ -172,6 +172,9 @@ class Security {
     * This function tries to authenticate using CGIAR's Active Directory
     * Authentication is done by trying to bind as the user. If binding fails
     * then the user is not authenticated
+    * Users are authenticated on both ILRI sub-domain & CGIAR root domain
+    * because some users' accounts have already been moved to the root DC
+    * as part of ICT's O365 initiative
     *
     * @param type $user Username to be authenticated
     * @param type $pass Unencrypted password
@@ -187,7 +190,14 @@ class Security {
        else {
           ldap_set_option($ldapConnection, LDAP_OPT_REFERRALS, 0);
           ldap_set_option($ldapConnection, LDAP_OPT_PROTOCOL_VERSION, 3);
-          $ldapBind = ldap_bind($ldapConnection, "$user@ilri.cgiarad.org", $pass);
+
+          $ldapBind = false;
+          if (ldap_bind($ldapConnection, "$user@ilri.cgiarad.org", $pass)){
+            $ldapBind = true;
+          } elseif (ldap_bind($ldapConnection, "$user@cgiarad.org", $pass)){
+            $ldapBind = true;
+          }
+
           if ($ldapBind) {
              $ldapSr = ldap_search($ldapConnection, Config::$config['ldapSSpace'], "(sAMAccountName=$user)", array('sn', 'givenName', 'title'));
 


### PR DESCRIPTION
As per ICT's O365 initiative, all accounts will be moved from ILRI's
subdomain to the root CGIARAD domain. We therefore need to authenticate
users on both domains as some accounts have already been moved to the
root domain.

Closes #1

https://github.com/ilri/azizi-shared-libs/issues/1
